### PR TITLE
DTP: no error or notice is thrown when drivetemp not enabled

### DIFF
--- a/source/dtp/dtp
+++ b/source/dtp/dtp
@@ -172,6 +172,11 @@ foreach my $Dir (glob("$HWMon/hwmon[0-9]*")) {
 	}
 }
 
+if (!keys %hash) {
+	print("No drivetemp device found\nPlease check if drivetemp kernel module enabled\n");
+	exit(1);
+}
+
 @Keys = keys(%Drives);
 
 if ($ShowHeader and scalar(@Keys)) {


### PR DESCRIPTION
Add a notice to enable `drivetemp` kernel module when it is disabled.
Usually distros such as arch comes mostly with only essential kernel modules enabled 
We can do that easily by checking `%Drives` if it is empty